### PR TITLE
Do not create virtual load on disconnected xnode

### DIFF
--- a/virtual-hubs-network-assigner/src/main/java/com/farao_community/farao/virtual_hubs/network_extension_builder/VirtualHubAssigner.java
+++ b/virtual-hubs-network-assigner/src/main/java/com/farao_community/farao/virtual_hubs/network_extension_builder/VirtualHubAssigner.java
@@ -44,11 +44,15 @@ public class VirtualHubAssigner {
         Optional<DanglingLine> danglingLine = findDanglingLineWithXNode(network, virtualHub.getNodeName());
         if (danglingLine.isPresent()) {
             // virtual hub is on a Xnode which has been merged in a dangling line during network import
-            addVirtualHubOnNewFictitiousLoad(danglingLine.get().getTerminal().getBusBreakerView().getConnectableBus(), virtualHub);
+            if (danglingLine.get().getTerminal().isConnected()) {
+                addVirtualHubOnNewFictitiousLoad(danglingLine.get().getTerminal().getBusBreakerView().getConnectableBus(), virtualHub);
+            } else {
+                LOGGER.warn("Virtual hub {} was not assigned on node {} as it is disconnected from the main network", virtualHub.getEic(), virtualHub.getNodeName());
+            }
             return;
         }
 
-        LOGGER.warn("Virtual hub cannot be assigned on node {} as it was not found in the network", virtualHub.getNodeName());
+        LOGGER.warn("Virtual hub {} cannot be assigned on node {} as it was not found in the network", virtualHub.getEic(), virtualHub.getNodeName());
     }
 
     private void addVirtualHubOnNewFictitiousLoad(Bus bus, VirtualHub virtualHub) {

--- a/virtual-hubs-network-assigner/src/test/java/com/farao_community/farao/virtual_hubs/network_extension_builder/VirtualHubAssignerTest.java
+++ b/virtual-hubs-network-assigner/src/test/java/com/farao_community/farao/virtual_hubs/network_extension_builder/VirtualHubAssignerTest.java
@@ -64,6 +64,19 @@ class VirtualHubAssignerTest {
     }
 
     @Test
+    void testAssignerDisconnectedXNode() {
+
+        network.getDanglingLine("FFR1AA1  X_GBFR1  1").getTerminal().disconnect();
+
+        virtualHubs.add(new VirtualHub("code_vh2", "eic_vh2", true, "X_GBFR1 ", new MarketArea("FR", "eic_fr", true)));
+        new VirtualHubAssigner(virtualHubs).addVirtualLoads(network);
+
+        Optional<Load> load = network.getLoadStream().filter(l -> l.getExtension(AssignedVirtualHub.class) != null).findFirst();
+        assertTrue(load.isEmpty());
+        assertNull(network.getLoad("eic_vh2_virtualLoad"));
+    }
+
+    @Test
     void testAssignerOnSeveralNodes() {
         virtualHubs.add(new VirtualHub("code_vh1", "eic_vh1", true, "NNL2AA1 ", new MarketArea("NL", "eic_nl", true)));
         virtualHubs.add(new VirtualHub("code_vh2", "eic_vh2", true, "X_GBFR1 ", new MarketArea("FR", "eic_fr", true)));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Do not create virtual load on disconnected xnode


**What is the current behavior?** *(You can also link to an open issue here)*
Virtual load is created, even if the Xnode is disconnected.
As the virtual load is connected on the other side of the dangling line, the GLSK based on this virtual load is misinterpreted and ignore the disconnection of the Xnode.


**What is the new behavior (if this is a feature change)?**
Virtual load are not created anymore when the Xnode is disconnected.

